### PR TITLE
Refactor to allow only one admin

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -1,5 +1,3 @@
-const { response } = require("express");
-
 const express = require("express"),
     router = express.Router(),
     userService = require("../services/user-service"),
@@ -7,7 +5,6 @@ const express = require("express"),
     tranService = require("../services/transaction-service"),
     itemService = require("../services/item-service"),
     exceptionHandler = require("../exceptions/exception-handler"),
-    userIsAuthenticated = require("./util/auth.js").userIsAuthenticated,
     userIsAdmin = require("./util/auth.js").userIsAdmin,
     dbUtil = require("../db/db-util"),
     copyTo = require('pg-copy-streams').to,
@@ -52,6 +49,14 @@ router.post('/users/create', [userIsAdmin], async function (req, res, next) {
             return;
         }
 
+        // if user is an admin, do nothing
+        if (type === 'admin') {
+            let adminCount = await userService.countAllAdmins();
+            if (adminCount == 2) {
+                res.status(500).send("Cannot create an additional admin");
+            }
+        }
+
         await userService.createUser(newOnyen, type, pid, email);
     } catch (e) {
         res.status(500).send("Internal server error");
@@ -78,18 +83,21 @@ router.post('/users/edit', [userIsAdmin], async function (req, res, next) {
         let pid = req.body.pid;
         let email = req.body.email;
 
-        // Checks to make sure there are at least two admins in the system
-        // PREORDER and one other admin
+        // Checks to make sure there are exactly two admins in the system (PREORDER and one other admin)
         let currType = await authService.getUserType(editOnyen);
+        let adminCount = await userService.countAllAdmins();
         if (currType === "admin" && req.body.type !== "admin") {
-            let adminCount = await userService.countAllAdmins();
             if (adminCount <= 2) {
                 res.status(500).send('Cannot remove the last admin');
                 return;
             }
+        } else if (currType !== "admin" && req.body.type === "admin") {
+            if (adminCount == 2) {
+                res.status(500).send('Cannot create more than one admin');
+                return;
+            }
         }
         await userService.editUser(editOnyen, type, pid, email);
-
     } catch (e) {
         res.status(500).send(exceptionHandler.retrieveException(e));
         return;
@@ -122,7 +130,6 @@ router.post('/users/delete', [userIsAdmin], async function (req, res, next) {
             }
         }
         await userService.deleteUser(delOnyen);
-
     } catch (e) {
         res.status(500).send("Internal server error");
         return;

--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -54,6 +54,7 @@ router.post('/users/create', [userIsAdmin], async function (req, res, next) {
             let adminCount = await userService.countAllAdmins();
             if (adminCount == 2) {
                 res.status(500).send("Cannot create an additional admin");
+                return;
             }
         }
 

--- a/services/user-service.js
+++ b/services/user-service.js
@@ -54,7 +54,7 @@ exports.countAllAdmins = async function () {
  */
 exports.createUser = async function (onyen, type, pid, email) {
     try {
-        // If user already exists, do nothing
+        // if user already exists, do nothing
         if (await User.count({ where: { onyen: onyen } }) > 0) {
             return;
         }

--- a/tests/controllers/admin.test.js
+++ b/tests/controllers/admin.test.js
@@ -42,7 +42,7 @@ describe('Admin Routes - GET pages', () => {
         });
     });
 
-    describe('GET /admin/users/import - volunteers import page', () => {
+    describe('GET /admin/users/import - admin import page', () => {
         it('expect success HTTP 200 status', (done) => {
             supertest(app).get('/admin/users/import')
                 .set(testUtil.commonHeaders)
@@ -143,6 +143,22 @@ describe('Admin Routes - Sanity Checks', () => {
         });
     });
 
+    describe('POST /admin/users/create - create a second admin', () => {
+        it('expect HTTP 500 status', (done) => {
+            let requestBody = {
+                onyen: 'admin',
+                type: 'admin',
+                pid: '10',
+                email: "test@test.com"
+            };
+            supertest(app).post('/admin/users/edit')
+                .set(testUtil.commonHeaders)
+                .set(testUtil.adminAuthHeaders)
+                .send(requestBody)
+                .expect(500, done);
+        });
+    });
+
     describe('POST /admin/users/delete - delete last remaining admin', () => {
         it('expect HTTP 500 status', (done) => {
             let requestBody = {
@@ -153,57 +169,6 @@ describe('Admin Routes - Sanity Checks', () => {
                 .set(testUtil.adminAuthHeaders)
                 .send(requestBody)
                 .expect(500, done);
-        });
-    });
-});
-
-describe('Admin Routes - Volunteer Management Workflow', () => {
-    before(async () => {
-        await dbUtil.preTestSetup();
-    });
-
-    describe('POST /admin/users/create - create new admin', () => {
-        it('expect success HTTP 302 status', (done) => {
-            let requestBody = {
-                onyen: 'admin',
-                type: 'admin',
-                pid: '10',
-                email: "test@test.com"
-            }
-            supertest(app).post('/admin/users/create')
-                .set(testUtil.commonHeaders)
-                .set(testUtil.adminAuthHeaders)
-                .send(requestBody)
-                .expect(302, done);
-        });
-    });
-
-    describe('POST /admin/users/edit - change newly created admin to user', () => {
-        it('expect success HTTP 302 status', (done) => {
-            let requestBody = {
-                onyen: 'admin',
-                type: 'user',
-                pid: '20',
-                email: "vol@test.com"
-            };
-            supertest(app).post('/admin/users/edit')
-                .set(testUtil.commonHeaders)
-                .set(testUtil.adminAuthHeaders)
-                .send(requestBody)
-                .expect(302, done);
-        });
-    });
-
-    describe('POST /admin/users/delete - delete newly created admin', () => {
-        it('expect success HTTP 302 status', (done) => {
-            let requestBody = {
-                onyen: 'admin'
-            };
-            supertest(app).post('/admin/users/delete')
-                .set(testUtil.commonHeaders)
-                .set(testUtil.adminAuthHeaders)
-                .send(requestBody)
-                .expect(302, done);
         });
     });
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -13,6 +13,16 @@
     <div class="row">
       <div class="col-sm-12 col-md-4">
         <div class="card">
+          <a class="card-link" href="/admin/users">
+            <div class="card-body">
+              <p class="card-title">Manage Users</p>
+              <p class="card-text">Add, edit, and delete users</p>
+            </div>
+          </a>
+        </div>
+      </div>
+      <div class="col-sm-12 col-md-4">
+        <div class="card">
           <a class="card-link" href="/admin/history">
             <div class="card-body">
               <p class="card-title">Transaction History</p>
@@ -31,6 +41,9 @@
           </a>
         </div>
       </div>
+    </div>
+    <br>    
+    <div class="row">
       <div class="col-sm-12 col-md-4">
         <div class="card">
           <a class="card-link" href="/entry">
@@ -41,9 +54,6 @@
           </a>
         </div>
       </div>
-    </div>
-    <br>    
-    <div class="row">
       <div class="col-sm-12 col-md-4">
         <div class="card">
           <a class="card-link" href="/preorders">


### PR DESCRIPTION
@Dafondo this PR makes it so only one admin can be allowed, fitting the Closet's requirement of a singular admin view. Would appreciate your review here, and any feedback on how the codebase can be streamlined even more (may not need some other stuff now that we're only supporting one admin and no volunteers, since a lot of the functionality is only available to this one account).

Let me know what you think