### PR TITLE
Increase test timeout to 15000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npm run prod",
     "dev": "cross-env NODE_ENV=dev nodemon index.js",
     "prod": "cross-env NODE_ENV=prod node index.js",
-    "test": "cross-env nyc --reporter=lcov --reporter=text mocha --recursive --exit 'tests'",
+    "test": "cross-env nyc --reporter=lcov --reporter=text mocha --timeout 15000 --recursive --exit 'tests'",
     "test:clean": "npm run bootstrap && npm run test",
     "bootstrap": "cross-env NODE_ENV=dev sh ./scripts/bootstrap.sh"
   },


### PR DESCRIPTION
Remote tests were failing because some test steps were taking longer than the default 2000ms timeout. Haven't tested other timeout values, but this one seems to work.